### PR TITLE
Add metadata filtering to email query agents

### DIFF
--- a/app/agents/plan_execute_agent.py
+++ b/app/agents/plan_execute_agent.py
@@ -2,6 +2,7 @@
 import json
 import tiktoken
 import os
+import re
 from typing import List, Dict, Any
 from langchain.schema import BaseMessage, HumanMessage, AIMessage
 
@@ -36,7 +37,7 @@ class PlanExecuteAgent:
         chain_of_thought.append({
             "step": 2,
             "type": "initial_query",
-            "content": f"Generated initial query: {initial_query}"
+            "content": f"Generated initial query: {json.dumps(initial_query)}"
         })
 
         # Get initial results
@@ -90,7 +91,7 @@ class PlanExecuteAgent:
             chain_of_thought.append({
                 "step": current_query_num + 3,
                 "type": "query_refinement",
-                "content": f"Refined query #{current_query_num + 1}: {refined_query}"
+                "content": f"Refined query #{current_query_num + 1}: {json.dumps(refined_query)}"
             })
 
             # Execute refined query
@@ -167,8 +168,8 @@ class PlanExecuteAgent:
         response = await self.llm_service.generate(plan_prompt, max_tokens=300)
         return response.strip()
 
-    async def _generate_initial_query(self, user_prompt: str, plan: str) -> str:
-        """Generate the initial broad query"""
+    async def _generate_initial_query(self, user_prompt: str, plan: str) -> Dict[str, Any]:
+        """Generate the initial broad query as a dict with optional filters"""
         query_prompt = f"""
         Based on this search strategy, create a search query to find relevant emails:
 
@@ -179,17 +180,18 @@ class PlanExecuteAgent:
 
         Search Query:
         """
-
         response = await self.llm_service.generate(query_prompt, max_tokens=100)
-        return response.strip()
+        query_text = response.strip()
+        filters = self._extract_filters(user_prompt)
+        return {"text": query_text, **filters}
 
     async def _refine_query(
-            self,
-            user_prompt: str,
-            plan: str,
-            current_results: List[Dict[str, Any]],
-            iteration: int
-    ) -> str:
+        self,
+        user_prompt: str,
+        plan: str,
+        current_results: List[Dict[str, Any]],
+        iteration: int,
+    ) -> Dict[str, Any]:
         """Generate a refined query based on current results"""
 
         # Analyze current results to inform refinement
@@ -213,7 +215,40 @@ class PlanExecuteAgent:
         """
 
         response = await self.llm_service.generate(refinement_prompt, max_tokens=100)
-        return response.strip()
+        query_text = response.strip()
+        filters = self._extract_filters(user_prompt)
+        return {"text": query_text, **filters}
+
+    def _extract_filters(self, text: str) -> Dict[str, Any]:
+        """Extract sender and date filters from text"""
+        filters: Dict[str, Any] = {}
+
+        sender_match = re.search(r"from\s+([\w.\-]+@[\w\.-]+)", text, re.IGNORECASE)
+        if sender_match:
+            filters["sender"] = sender_match.group(1)
+
+        start = None
+        end = None
+
+        exact_match = re.search(r"on\s+(\d{4}-\d{2}-\d{2})", text)
+        if exact_match:
+            start = exact_match.group(1)
+            end = exact_match.group(1)
+
+        after_match = re.search(r"(?:after|since)\s+(\d{4}-\d{2}-\d{2})", text, re.IGNORECASE)
+        if after_match:
+            start = after_match.group(1)
+
+        before_match = re.search(r"before\s+(\d{4}-\d{2}-\d{2})", text, re.IGNORECASE)
+        if before_match:
+            end = before_match.group(1)
+
+        if start:
+            filters["start_date"] = start
+        if end:
+            filters["end_date"] = end
+
+        return filters
 
     def _merge_and_deduplicate(
             self,

--- a/app/agents/tool_using_agent.py
+++ b/app/agents/tool_using_agent.py
@@ -1,5 +1,5 @@
 # app/agents/tool_using_agent.py
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Union
 from services.chroma_service import ChromaService
 import re
 
@@ -8,7 +8,7 @@ class ToolUsingAgent:
     def __init__(self, chroma_service: ChromaService):
         self.chroma_service = chroma_service
 
-    async def execute_query(self, query: str) -> List[Dict[str, Any]]:
+    async def execute_query(self, query: Union[str, Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Execute a query against the email database"""
 
         # Parse query to extract search parameters
@@ -16,9 +16,9 @@ class ToolUsingAgent:
 
         # Execute search in ChromaDB
         results = await self.chroma_service.search(
-            query_text=search_params.get('text', query),
-            n_results=search_params.get('limit', 25),
-            where=search_params.get('filters', None)  # Pass None instead of empty dict
+            query_text=search_params.get("text", query if isinstance(query, str) else ""),
+            n_results=search_params.get("limit", 25),
+            where=search_params.get("filters")
         )
 
         # Ensure results are properly formatted
@@ -38,25 +38,53 @@ class ToolUsingAgent:
 
         return formatted_results
 
-    def _parse_query(self, query: str) -> Dict[str, Any]:
-        """Parse query to extract search parameters"""
-        params = {
-            'text': query,
-            'limit': 25,
-            'filters': None  # Start with None
+    def _parse_query(self, query: Union[str, Dict[str, Any]]) -> Dict[str, Any]:
+        """Parse query to build text and metadata filters for Chroma"""
+
+        params: Dict[str, Any] = {
+            "text": "",
+            "limit": 25,
+            "filters": {},
         }
 
-        # For now, disabled complex filtering and rely on semantic search
-        # ChromaDB's where clause has specific requirements that are causing issues
+        if isinstance(query, dict):
+            params["text"] = query.get("text", "")
+            if "limit" in query:
+                params["limit"] = query["limit"]
+            sender = query.get("sender")
+            if sender:
+                params["filters"]["sender"] = sender
+            start = query.get("start_date")
+            end = query.get("end_date")
+            if start or end:
+                date_filter: Dict[str, Any] = {}
+                if start:
+                    date_filter["$gte"] = start
+                if end:
+                    date_filter["$lte"] = end
+                params["filters"]["date"] = date_filter
+        else:
+            params["text"] = query
+            q_lower = query.lower()
 
-        # Extract specific search patterns but don't use them as filters
-        query_lower = query.lower()
+            if any(word in q_lower for word in ["all", "every", "list", "show me"]):
+                params["limit"] = 50
+            elif any(word in q_lower for word in ["specific", "exact", "particular"]):
+                params["limit"] = 15
 
-        # Adjust result limit based on query characteristics
-        if any(word in query_lower for word in ['all', 'every', 'list', 'show me']):
-            params['limit'] = 50  # Broader queries might need more results
-        elif any(word in query_lower for word in ['specific', 'exact', 'particular']):
-            params['limit'] = 15  # More specific queries need fewer results
+            sender_match = re.search(r"from[: ]+(\S+@\S+)", q_lower)
+            if sender_match:
+                params["filters"]["sender"] = sender_match.group(1)
 
-        # For complex filtering, we'll handle it post-search in the results
+            after_match = re.search(r"(after|since)[: ]+(\d{4}-\d{2}-\d{2})", q_lower)
+            if after_match:
+                params.setdefault("filters", {}).setdefault("date", {})["$gte"] = after_match.group(2)
+
+            before_match = re.search(r"before[: ]+(\d{4}-\d{2}-\d{2})", q_lower)
+            if before_match:
+                params.setdefault("filters", {}).setdefault("date", {})["$lte"] = before_match.group(1)
+
+        if not params["filters"]:
+            params["filters"] = None
+
         return params

--- a/app/services/chroma_service.py
+++ b/app/services/chroma_service.py
@@ -83,10 +83,10 @@ class ChromaService:
         print(f"Successfully added email {email_id} to ChromaDB")
 
     async def search(
-            self,
-            query_text: str,
-            n_results: int = 10,
-            where: Optional[Dict] = None
+        self,
+        query_text: str,
+        n_results: int = 10,
+        where: Optional[Dict] = None,
     ) -> List[Dict[str, Any]]:
         """Search emails in ChromaDB"""
 
@@ -101,7 +101,8 @@ class ChromaService:
             results = self.collection.query(
                 query_embeddings=[query_embedding],
                 n_results=n_results,
-                include=['documents', 'metadatas', 'distances']
+                include=["documents", "metadatas", "distances"],
+                where=where,
             )
         except Exception as e:
             print(f"ChromaDB query error: {e}")


### PR DESCRIPTION
## Summary
- allow tool agent to pass `where` filter to ChromaDB
- generate query dicts with date/sender filters in plan/execute agent
- parse sender/date filters in tool agent
- support where clause in Chroma service

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68501e22ab40832fa0ad7e0f8afc066e