### PR TITLE
Add chunked embedding uploads and enforce query limits

### DIFF
--- a/app/agents/plan_execute_agent.py
+++ b/app/agents/plan_execute_agent.py
@@ -2,6 +2,7 @@
 import json
 import tiktoken
 import os
+import re
 from typing import List, Dict, Any
 from langchain.schema import BaseMessage, HumanMessage, AIMessage
 
@@ -36,7 +37,7 @@ class PlanExecuteAgent:
         chain_of_thought.append({
             "step": 2,
             "type": "initial_query",
-            "content": f"Generated initial query: {initial_query}"
+            "content": f"Generated initial query: {json.dumps(initial_query)}"
         })
 
         # Get initial results
@@ -45,7 +46,7 @@ class PlanExecuteAgent:
         chain_of_thought.append({
             "step": 3,
             "type": "initial_results",
-            "content": f"Retrieved {len(email_results)} initial email results"
+            "content": f"Retrieved {len(email_results)} initial chunks"
         })
 
         if not email_results:
@@ -67,7 +68,7 @@ class PlanExecuteAgent:
             chain_of_thought.append({
                 "step": current_query_num + 3,
                 "type": "token_check",
-                "content": f"Current context tokens: {current_tokens}/{self.max_context_tokens} with {len(filtered_results)} emails"
+                "content": f"Current context tokens: {current_tokens}/{self.max_context_tokens} with {len(filtered_results)} chunks"
             })
 
             # If within limits, we're good to proceed
@@ -81,7 +82,7 @@ class PlanExecuteAgent:
                 chain_of_thought.append({
                     "step": current_query_num + 3,
                     "type": "aggressive_filtering",
-                    "content": f"Applied aggressive filtering, reduced to {len(filtered_results)} emails"
+                    "content": f"Applied aggressive filtering, reduced to {len(filtered_results)} chunks"
                 })
                 break
 
@@ -90,7 +91,7 @@ class PlanExecuteAgent:
             chain_of_thought.append({
                 "step": current_query_num + 3,
                 "type": "query_refinement",
-                "content": f"Refined query #{current_query_num + 1}: {refined_query}"
+                "content": f"Refined query #{current_query_num + 1}: {json.dumps(refined_query)}"
             })
 
             # Execute refined query
@@ -102,7 +103,7 @@ class PlanExecuteAgent:
             chain_of_thought.append({
                 "step": current_query_num + 3,
                 "type": "refined_results",
-                "content": f"After refinement: {len(filtered_results)} total unique emails"
+                "content": f"After refinement: {len(filtered_results)} total unique chunks"
             })
 
             current_query_num += 1
@@ -118,15 +119,15 @@ class PlanExecuteAgent:
             chain_of_thought.append({
                 "step": "emergency_filter",
                 "type": "emergency_filtering",
-                "content": f"Applied emergency filtering: {len(filtered_results)} emails, {final_tokens} tokens"
+                "content": f"Applied emergency filtering: {len(filtered_results)} chunks, {final_tokens} tokens"
             })
 
             if final_tokens > self.max_context_tokens:
                 return {
-                    "error": f"Unable to reduce context to fit within {self.max_context_tokens} token limit. Found relevant emails but context is too large.",
+                    "error": f"Unable to reduce context to fit within {self.max_context_tokens} token limit. Found relevant chunks but context is too large.",
                     "chain_of_thought": chain_of_thought,
                     "emails_found": len(email_results),
-                    "final_emails": len(filtered_results)
+                    "final_emails": final_tokens
                 }
 
         # Step 4: Generate final response with email context
@@ -135,7 +136,7 @@ class PlanExecuteAgent:
         chain_of_thought.append({
             "step": "final",
             "type": "response_generation",
-            "content": f"Generated response using {len(filtered_results)} emails as context ({final_tokens} tokens)"
+            "content": f"Generated response using {len(filtered_results)} chunks as context ({final_tokens} tokens)"
         })
 
         return {
@@ -143,7 +144,7 @@ class PlanExecuteAgent:
             "chain_of_thought": chain_of_thought,
             "context_tokens_used": final_tokens,
             "queries_executed": current_query_num,
-            "emails_analyzed": len(filtered_results)
+            "emails_analyzed": final_tokens
         }
 
     async def _create_plan(self, user_prompt: str) -> str:
@@ -167,8 +168,8 @@ class PlanExecuteAgent:
         response = await self.llm_service.generate(plan_prompt, max_tokens=300)
         return response.strip()
 
-    async def _generate_initial_query(self, user_prompt: str, plan: str) -> str:
-        """Generate the initial broad query"""
+    async def _generate_initial_query(self, user_prompt: str, plan: str) -> Dict[str, Any]:
+        """Generate the initial broad query as a dict with optional filters"""
         query_prompt = f"""
         Based on this search strategy, create a search query to find relevant emails:
 
@@ -179,17 +180,18 @@ class PlanExecuteAgent:
 
         Search Query:
         """
-
         response = await self.llm_service.generate(query_prompt, max_tokens=100)
-        return response.strip()
+        query_text = response.strip()
+        filters = self._extract_filters(user_prompt)
+        return {"text": query_text, "limit": 20, **filters}
 
     async def _refine_query(
-            self,
-            user_prompt: str,
-            plan: str,
-            current_results: List[Dict[str, Any]],
-            iteration: int
-    ) -> str:
+        self,
+        user_prompt: str,
+        plan: str,
+        current_results: List[Dict[str, Any]],
+        iteration: int,
+    ) -> Dict[str, Any]:
         """Generate a refined query based on current results"""
 
         # Analyze current results to inform refinement
@@ -213,7 +215,40 @@ class PlanExecuteAgent:
         """
 
         response = await self.llm_service.generate(refinement_prompt, max_tokens=100)
-        return response.strip()
+        query_text = response.strip()
+        filters = self._extract_filters(user_prompt)
+        return {"text": query_text, "limit": 20, **filters}
+
+    def _extract_filters(self, text: str) -> Dict[str, Any]:
+        """Extract sender and date filters from text"""
+        filters: Dict[str, Any] = {}
+
+        sender_match = re.search(r"from\s+([\w.\-]+@[\w\.-]+)", text, re.IGNORECASE)
+        if sender_match:
+            filters["sender"] = sender_match.group(1)
+
+        start = None
+        end = None
+
+        exact_match = re.search(r"on\s+(\d{4}-\d{2}-\d{2})", text)
+        if exact_match:
+            start = exact_match.group(1)
+            end = exact_match.group(1)
+
+        after_match = re.search(r"(?:after|since)\s+(\d{4}-\d{2}-\d{2})", text, re.IGNORECASE)
+        if after_match:
+            start = after_match.group(1)
+
+        before_match = re.search(r"before\s+(\d{4}-\d{2}-\d{2})", text, re.IGNORECASE)
+        if before_match:
+            end = before_match.group(1)
+
+        if start:
+            filters["start_date"] = start
+        if end:
+            filters["end_date"] = end
+
+        return filters
 
     def _merge_and_deduplicate(
             self,
@@ -275,15 +310,8 @@ class PlanExecuteAgent:
         if not email_results:
             return 0
 
-        # Create a text representation of the emails for token counting
-        email_text = ""
-        for email in email_results:
-            email_text += f"Subject: {email.get('subject', '')}\n"
-            email_text += f"From: {email.get('sender', '')}\n"
-            email_text += f"Date: {email.get('date', '')}\n"
-            email_text += f"Content: {email.get('content', '')}\n\n"
-
-        return len(self.encoder.encode(email_text))
+        content_text = "\n".join(email.get("content", "") for email in email_results)
+        return len(self.encoder.encode(content_text))
 
     async def _generate_final_response(
             self,

--- a/app/agents/tool_using_agent.py
+++ b/app/agents/tool_using_agent.py
@@ -1,5 +1,5 @@
 # app/agents/tool_using_agent.py
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Union
 from services.chroma_service import ChromaService
 import re
 
@@ -8,7 +8,7 @@ class ToolUsingAgent:
     def __init__(self, chroma_service: ChromaService):
         self.chroma_service = chroma_service
 
-    async def execute_query(self, query: str) -> List[Dict[str, Any]]:
+    async def execute_query(self, query: Union[str, Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Execute a query against the email database"""
 
         # Parse query to extract search parameters
@@ -16,9 +16,9 @@ class ToolUsingAgent:
 
         # Execute search in ChromaDB
         results = await self.chroma_service.search(
-            query_text=search_params.get('text', query),
-            n_results=search_params.get('limit', 25),
-            where=search_params.get('filters', None)  # Pass None instead of empty dict
+            query_text=search_params.get("text", query if isinstance(query, str) else ""),
+            n_results=search_params.get("limit", 20),
+            where=search_params.get("filters")
         )
 
         # Ensure results are properly formatted
@@ -38,25 +38,54 @@ class ToolUsingAgent:
 
         return formatted_results
 
-    def _parse_query(self, query: str) -> Dict[str, Any]:
-        """Parse query to extract search parameters"""
-        params = {
-            'text': query,
-            'limit': 25,
-            'filters': None  # Start with None
+    def _parse_query(self, query: Union[str, Dict[str, Any]]) -> Dict[str, Any]:
+        """Parse query to build text and metadata filters for Chroma"""
+
+        params: Dict[str, Any] = {
+            "text": "",
+            "limit": 20,
+            "filters": {},
         }
 
-        # For now, disabled complex filtering and rely on semantic search
-        # ChromaDB's where clause has specific requirements that are causing issues
+        if isinstance(query, dict):
+            params["text"] = query.get("text", "")
+            if "limit" in query:
+                params["limit"] = query["limit"]
+            sender = query.get("sender")
+            if sender:
+                params["filters"]["sender"] = sender
+            start = query.get("start_date")
+            end = query.get("end_date")
+            if start or end:
+                date_filter: Dict[str, Any] = {}
+                if start:
+                    date_filter["$gte"] = start
+                if end:
+                    date_filter["$lte"] = end
+                params["filters"]["date"] = date_filter
+        else:
+            params["text"] = query
+            q_lower = query.lower()
 
-        # Extract specific search patterns but don't use them as filters
-        query_lower = query.lower()
+            if any(word in q_lower for word in ["all", "every", "list", "show me"]):
+                params["limit"] = 20
+            elif any(word in q_lower for word in ["specific", "exact", "particular"]):
+                params["limit"] = 15
 
-        # Adjust result limit based on query characteristics
-        if any(word in query_lower for word in ['all', 'every', 'list', 'show me']):
-            params['limit'] = 50  # Broader queries might need more results
-        elif any(word in query_lower for word in ['specific', 'exact', 'particular']):
-            params['limit'] = 15  # More specific queries need fewer results
+            sender_match = re.search(r"from[: ]+(\S+@\S+)", q_lower)
+            if sender_match:
+                params["filters"]["sender"] = sender_match.group(1)
 
-        # For complex filtering, we'll handle it post-search in the results
+            after_match = re.search(r"(after|since)[: ]+(\d{4}-\d{2}-\d{2})", q_lower)
+            if after_match:
+                params.setdefault("filters", {}).setdefault("date", {})["$gte"] = after_match.group(2)
+
+            before_match = re.search(r"before[: ]+(\d{4}-\d{2}-\d{2})", q_lower)
+            if before_match:
+                params.setdefault("filters", {}).setdefault("date", {})["$lte"] = before_match.group(1)
+
+        params["limit"] = min(max(params.get("limit", 20), 1), 20)
+        if not params["filters"]:
+            params["filters"] = None
+
         return params

--- a/app/services/chroma_service.py
+++ b/app/services/chroma_service.py
@@ -3,6 +3,8 @@ import os
 import chromadb
 from chromadb.config import Settings
 from typing import List, Dict, Any, Optional
+import math
+import tiktoken
 from sentence_transformers import SentenceTransformer
 
 
@@ -11,6 +13,31 @@ class ChromaService:
         self.client = None
         self.collection = None
         self.embedder = None
+        self.tokenizer = tiktoken.get_encoding("cl100k_base")
+
+    def _chunk_text(
+        self, text: str, max_tokens: int = 1000, overlap_ratio: float = 0.15
+    ) -> List[str]:
+        """Chunk text into pieces <= max_tokens with specified overlap."""
+        tokens = self.tokenizer.encode(text)
+        total = len(tokens)
+        if total <= max_tokens:
+            return [text]
+
+        num_chunks = math.ceil(total / max_tokens)
+        chunk_size = min(max_tokens, math.ceil(total / num_chunks))
+        step = max(1, int(chunk_size * (1 - overlap_ratio)))
+
+        chunks = []
+        start = 0
+        while start < total:
+            chunk_tokens = tokens[start : start + chunk_size]
+            chunks.append(self.tokenizer.decode(chunk_tokens))
+            if start + chunk_size >= total:
+                break
+            start += step
+
+        return chunks
 
     async def initialize(self):
         """Initialize ChromaDB client and collection"""
@@ -39,59 +66,59 @@ class ChromaService:
         if not self.collection:
             await self.initialize()
 
-        # Get the email body content
-        body_content = email_data.get('body', '')
-        subject = email_data.get('subject', '')
+        body_content = email_data.get("body", "")
+        subject = email_data.get("subject", "")
 
-        # Create content for embedding (subject + body)
-        embedding_content = f"{subject} {body_content}"
+        print(
+            f"Adding email to ChromaDB: Subject='{subject}', Body length={len(body_content)}"
+        )
 
-        # Debug print
-        print(f"Adding email to ChromaDB: Subject='{subject}', Body length={len(body_content)}")
+        # Determine chunks for the body content
+        chunks = self._chunk_text(body_content)
 
-        # Create embedding
-        embedding = self.embedder.encode(embedding_content).tolist()
-
-        # Generate unique ID if not provided
-        email_id = email_data.get('message_id')
+        email_id = email_data.get("message_id")
         if not email_id:
             try:
                 existing = self.collection.get()
                 email_id = f"email_{len(existing['ids'])}"
-            except:
+            except Exception:
                 email_id = "email_0"
 
-        # Store the full body content in the document field
-        # This is crucial - the document field is what gets returned in searches
-        document_content = body_content if body_content else subject
+        for idx, chunk in enumerate(chunks, 1):
+            embedding_content = f"{subject} {chunk}"
+            embedding = self.embedder.encode(embedding_content).tolist()
 
-        # Add to collection
-        self.collection.add(
-            embeddings=[embedding],
-            documents=[document_content],  # This should contain the email body
-            metadatas=[{
-                'subject': subject,
-                'sender': email_data.get('sender', ''),
-                'recipient': email_data.get('recipient', ''),
-                'date': email_data.get('date', ''),
-                'message_id': email_id,
-                'body_length': len(body_content)  # Store body length for debugging
-            }],
-            ids=[email_id]
-        )
+            chunk_id = f"{email_id}_chunk{idx}"
+            self.collection.add(
+                embeddings=[embedding],
+                documents=[chunk],
+                metadatas=[{
+                    "subject": subject,
+                    "sender": email_data.get("sender", ""),
+                    "recipient": email_data.get("recipient", ""),
+                    "date": email_data.get("date", ""),
+                    "message_id": email_id,
+                    "chunk_index": idx,
+                    "total_chunks": len(chunks),
+                    "body_length": len(chunk),
+                }],
+                ids=[chunk_id],
+            )
 
-        print(f"Successfully added email {email_id} to ChromaDB")
+        print(f"Successfully added email {email_id} with {len(chunks)} chunks to ChromaDB")
 
     async def search(
-            self,
-            query_text: str,
-            n_results: int = 10,
-            where: Optional[Dict] = None
+        self,
+        query_text: str,
+        n_results: int = 10,
+        where: Optional[Dict] = None,
     ) -> List[Dict[str, Any]]:
         """Search emails in ChromaDB"""
 
         if not self.collection:
             await self.initialize()
+
+        n_results = min(max(n_results, 1), 20)
 
         # Create query embedding
         query_embedding = self.embedder.encode(query_text).tolist()
@@ -101,7 +128,8 @@ class ChromaService:
             results = self.collection.query(
                 query_embeddings=[query_embedding],
                 n_results=n_results,
-                include=['documents', 'metadatas', 'distances']
+                include=["documents", "metadatas", "distances"],
+                where=where,
             )
         except Exception as e:
             print(f"ChromaDB query error: {e}")


### PR DESCRIPTION
## Summary
- chunk emails over 1k tokens with 15% overlap when adding to Chroma
- restrict search to at most 20 results
- generate queries with limit and handle chunk counts in plan agent
- compute token counts only from returned chunks

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68501e22ab40832fa0ad7e0f8afc066e